### PR TITLE
Pops wander around randomly when no targets are within range

### DIFF
--- a/src/@types/Pop.ts
+++ b/src/@types/Pop.ts
@@ -22,4 +22,6 @@ export interface PopStats {
     size: number;
     range: number;
     speed: number;
+    wanderDuration: number;
+    wanderDirection: { x: number, y: number };
 }

--- a/src/classes/Pop.ts
+++ b/src/classes/Pop.ts
@@ -4,6 +4,7 @@ import Matter, { Bodies, Composite, Vector, Body, Constraint } from "matter-js";
 import { PopAppearance, PopConfiguration, PopStats, PopType } from "../@types/Pop";
 
 import { DetectedObjects, DETECTED_OBJECTS } from "../configs/DetectedObjects";
+import { Common } from "matter-js";
 
 export interface WorldConfiguration {
     worldOffset: number;
@@ -13,12 +14,9 @@ export interface WorldConfiguration {
 
 class Pop {
     id: number;
-    // position: Vector;
     terrainDetected: Boolean;
-
     stats: PopStats;
     appearance: PopAppearance;
-
     detectedObjects: DetectedObjects;
 
     // Physical bodies
@@ -144,6 +142,20 @@ class Pop {
         const gap = findLargestGap(angles);
         const bestPath = bisectLargestAngles(gap);
         return bestPath;
+    }
+
+    /**
+     * Pops will wander in random directions while no one is in their FOV
+     */
+    wander(pop: Pop, x: number, y: number, duration: number, deltaT: number) {
+        if (pop.stats.wanderDuration > 0) {
+            pop.stats.wanderDuration -= 1
+            this.moveTowards(Vector.create(x, y), deltaT)
+        }
+        else {
+            pop.stats.wanderDuration = duration
+            pop.stats.wanderDirection = { x: Common.random(-0.05, 0.05), y: Common.random(-0.05, 0.05) }
+        }
     }
 }
 

--- a/src/classes/Pop.ts
+++ b/src/classes/Pop.ts
@@ -147,14 +147,14 @@ class Pop {
     /**
      * Pops will wander in random directions while no one is in their FOV
      */
-    wander(pop: Pop, x: number, y: number, duration: number, deltaT: number) {
-        if (pop.stats.wanderDuration > 0) {
-            pop.stats.wanderDuration -= 1
+    wander(x: number, y: number, duration: number, deltaT: number) {
+        if (this.stats.wanderDuration > 0) {
+            this.stats.wanderDuration -= 1
             this.moveTowards(Vector.create(x, y), deltaT)
         }
         else {
-            pop.stats.wanderDuration = duration
-            pop.stats.wanderDirection = { x: Common.random(-0.05, 0.05), y: Common.random(-0.05, 0.05) }
+            this.stats.wanderDuration = duration
+            this.stats.wanderDirection = { x: Common.random(-0.05, 0.05), y: Common.random(-0.05, 0.05) }
         }
     }
 }

--- a/src/classes/World.ts
+++ b/src/classes/World.ts
@@ -56,7 +56,7 @@ export class World {
     }
 
     initPops() {
-        for (let i = 0; i < 50; i++) {
+        for (let i = 0; i < 20; i++) {
             const pop = new Pop(
                 i,
                 Vector.create(Math.random() * window.innerWidth, Math.random() * window.innerHeight), // position
@@ -273,6 +273,9 @@ export class World {
                 if (pop.stats.popType === PopType.humanoid) {
                     const bestPath = pop.smartPathing(this.filterVisible(pop, pop.detectedObjects));
                     pop.moveTowards(bestPath, this.engine.timing.lastDelta);
+                }
+                if ((pop.stats.popType === PopType.humanoid && pop.detectedObjects.Zomboid.length === 0) || (pop.stats.popType === PopType.zomboid && pop.detectedObjects.Humanoid.length === 0)) {
+                    pop.wander(pop, pop.stats.wanderDirection.x, pop.stats.wanderDirection.y, 500, this.engine.timing.lastDelta)
                 }
 
                 // Infectoids spaz out

--- a/src/components/MatterCanvas.tsx
+++ b/src/components/MatterCanvas.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import useInitMatter from '../hooks/useInitMatter';
 
 function MatterCanvas(): React.ReactElement {
-    useInitMatter("matter-canvas");
+    const { reset } = useInitMatter("matter-canvas");
 
     return (
-        <div id="matter-canvas">
-
+        <div>
+            <div id="matter-canvas"></div>
+            <button onKeyDown={(event) => {
+                console.log(event);
+                reset();
+            }}>Restart</button>
         </div>
+
     );
 };
 

--- a/src/configs/InfectoidConfig.ts
+++ b/src/configs/InfectoidConfig.ts
@@ -1,11 +1,14 @@
 import { PopAppearance, PopStats, PopType } from "../@types/Pop"
 import { DEFAULT_POP_APPEARANCE } from "./PopConfig"
+import { Common } from "matter-js"
 
 export const DEFAULT_INFECTOID_STATS: PopStats = {
     popType: PopType.infectoid,
     size: 10,
     range: 250,
     speed: 1.1,
+    wanderDuration: 3,
+    wanderDirection: { x: Common.random(-0.05, 0.05), y: Common.random(-0.05, 0.05) },
 }
 
 export const DEFAULT_INFECTOID_APPEARANCE: PopAppearance = {

--- a/src/configs/PopConfig.ts
+++ b/src/configs/PopConfig.ts
@@ -1,10 +1,13 @@
 import { PopAppearance, PopStats, PopType } from "../@types/Pop"
+import { Common } from "matter-js"
 
 export const DEFAULT_POP_STATS: PopStats = {
     popType: PopType.humanoid,
     size: 10,
-    range: 100,
-    speed: 1,
+    range: 200,
+    speed: 0.9,
+    wanderDuration: 3,
+    wanderDirection: { x: Common.random(-0.05, 0.05), y: Common.random(-0.05, 0.05) },
 }
 
 export const DEFAULT_POP_APPEARANCE: PopAppearance = {

--- a/src/configs/ZomboidConfig.ts
+++ b/src/configs/ZomboidConfig.ts
@@ -1,10 +1,13 @@
 import { PopAppearance, PopStats, PopType } from "../@types/Pop"
+import { Common } from "matter-js"
 
 export const DEFAULT_ZOMBOID_STATS: PopStats = {
     popType: PopType.zomboid,
     size: 10,
-    range: 150,
-    speed: 0.5,
+    range: 250,
+    speed: 1,
+    wanderDuration: 3,
+    wanderDirection: { x: Common.random(-0.05, 0.05), y: Common.random(-0.05, 0.05) },
 }
 
 export const DEFAULT_ZOMBOID_APPEARANCE: PopAppearance = {

--- a/src/hooks/useInitMatter.ts
+++ b/src/hooks/useInitMatter.ts
@@ -5,6 +5,12 @@ import { World } from "../classes/World";
 
 const useInitMatter = (elementId: string) => {
     const [hasInitialized, setHasInitialized] = React.useState(false);
+    const [matterObjects, setMatterObjects] = React.useState<{ world?: World, engine?: Engine, render?: Render, runner?: Runner }>({
+        world: undefined,
+        engine: undefined,
+        render: undefined,
+        runner: undefined,
+    })
 
     function initMatter() {
         if (hasInitialized) return;
@@ -40,10 +46,29 @@ const useInitMatter = (elementId: string) => {
         Runner.run(runner, engine);
 
         new World(engine);
+
+        setMatterObjects({
+            engine, runner, render,
+        })
+    }
+
+    function reset() {
+        clear();
+        initMatter();
+    }
+
+    function clear() {
+        if (!hasInitialized) return;
+
+        Engine.clear(matterObjects.engine!);
+        Render.stop(matterObjects.render!);
+        Runner.stop(matterObjects.runner!);
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     React.useEffect(() => initMatter(), [elementId]);
+
+    return { initMatter, reset, clear }
 }
 
 export default useInitMatter;


### PR DESCRIPTION
Issues: When other pops get infected within a pop's field of view, it does not update the radar correctly. Therefore, some pops will not start wandering until the other pops leave their field of view and the radar gets reset.